### PR TITLE
Corrected support for languages with multiple alphabet rule variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ To simplify process described above, script `utftexindy.lua` is provided.
 `ieclib` with `T1, T2A, T2B, T2C, T3, T5` and `LGR` font encoding is loaded,
 all command line options are passed to `texindy`, with exception of the `-L` 
 option for language, which is transformed to `-M lang/<langname>/utf8-lang`.
-It is also possible to use language variants, specified after slash, like 
-`slovak/large`.
+It is also possible to use the languages with multiple alphabet rule
+variants, like `slovak-large`, `slovak-small`, `spanish-modern`,
+`spanish-traditional`, ... that are correctly transformed into
+`-M lang/<lang>/<variant>-utf8-lang`.
 
 ### Example:
 

--- a/utftexindy.lua
+++ b/utftexindy.lua
@@ -64,7 +64,7 @@ local output = iec.process(input)
 -- support languages with multiple alphabet rule variants
 -- ie. slovak-large, slovak-small, spanish-modern, spanish-traditional,... etc.
 -- see http://xindy.sourceforge.net/doc/make-rules-alphabets-doc.pdf
-local` langsep = "/"
+local langsep = "/"
 
 if lang:match "-" then langsep = "-" end
 

--- a/utftexindy.lua
+++ b/utftexindy.lua
@@ -61,13 +61,14 @@ end
 -- local input = io.read("*all")
 local output = iec.process(input)
 
--- support language variants
--- ie. slovak/large
-local langsep = "/"
+-- support languages with multiple alphabet rule variants
+-- ie. slovak-large, slovak-small, spanish-modern, spanish-traditional,... etc.
+-- see http://xindy.sourceforge.net/doc/make-rules-alphabets-doc.pdf
+local` langsep = "/"
 
-if lang:match "/" then langsep = "-" end
+if lang:match "-" then langsep = "-" end
 
-local langmodule = "lang/"..lang.. langsep .. "utf8-lang"
+local langmodule = "lang/"..lang:gsub("-", "/")..langsep.."utf8-lang"
 
 local xindyopt = {"-i", "-M", langmodule}
 for _, o in ipairs(arg) do


### PR DESCRIPTION
 Some languages like Slovak or Spanish have multiple alphabet rule variants in _xindy_ [1]. For instance, there is not even a language called e.g. 'slovak' or 'spanish'. User must specify the language together with alphabet rule variant e.i. 'slovak-large', 'slovak-small', "spanish-modern", "spanish-traditional", ... Until recently [2], `utftexindy.lua` script did not allow user to specify the alphabet rule variant, thus it practically supported only the languages with single alphabet rule variant, like 'english' or 'czech' or 'icelandic'. 

Nevertheless, the recent fix [2] associated the `-L` option with the alphabet rule variant separated by slash, e.g. 'slovak/large', 'slovak/small', 'spanish/modern', 'spanish/traditional', ... This declines from the way how _xindy_ refer to a language and it might be confusing for a regular _xindy_ (_texindy_) user.

This patch tweaks the recent fix in order to follow _xindy_'s language-name conventions.

[1] http://xindy.sourceforge.net/doc/make-rules-alphabets-doc.pdf
[2] Issue #1
